### PR TITLE
Replace -lsnmp with -lnetsnmp

### DIFF
--- a/generator/net_snmp.go
+++ b/generator/net_snmp.go
@@ -1,7 +1,7 @@
 package main
 
 /*
-#cgo LDFLAGS: -lsnmp
+#cgo LDFLAGS: -lnetsnmp
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/mib_api.h>
 #include <unistd.h>


### PR DESCRIPTION
Net-snmp library is at libnetsnmp.so, we use that instead of libsnmp.so.